### PR TITLE
Add argument to calculate coverage from multivariate normal (not to be merged)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Suggests:
     randomPlantedForest,
     rmarkdown,
     testthat (>= 3.0.0),
-    xgboost
+    xgboost, 
+    ranger
 LinkingTo: 
     Rcpp
 VignetteBuilder: 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(autoplot,glex)
 S3method(autoplot,glex_vi)
+S3method(glex,ranger)
 S3method(glex,rpf)
 S3method(glex,xgb.Booster)
 S3method(print,glex)

--- a/R/glex.R
+++ b/R/glex.R
@@ -115,6 +115,12 @@ glex.xgb.Booster <- function(object, x, max_interaction = NULL, ...) {
   # Convert model
   trees <- xgboost::xgb.model.dt.tree(model = object, use_int_id = TRUE)
 
+  # Calculate components
+  calc_components(trees, x, max_interaction)
+} 
+
+calc_components <- function(trees, x, max_interaction) {
+  
   # Function to get all subsets of set
   subsets <- function(x) {
     if (length(x) == 1) {

--- a/R/glex.R
+++ b/R/glex.R
@@ -15,6 +15,7 @@
 #'  Defaults to using all possible interactions available in the model.\cr
 #'  For [`xgboost`][xgboost::xgb.train], this defaults to the `max_depth` parameter of the model fit.\cr
 #'  If not set in `xgboost`, the default value of `6` is assumed.
+#' @param features Vector of column names in x to calculate components for. If \code{NULL}, all features are used.
 #' @param ... Further arguments passed to methods.
 #'
 #' @return Decomposition of the regression or classification function.
@@ -26,7 +27,7 @@
 #'   with `:` separating interaction terms as one would specify in a [`formula`] interface.
 #' * `intercept`: Intercept term, the expected value of the prediction.
 #' @export
-glex <- function(object, x, max_interaction = NULL, ...) {
+glex <- function(object, x, max_interaction = NULL, features = NULL, ...) {
   UseMethod("glex")
 }
 
@@ -51,7 +52,7 @@ glex.default <- function(object, ...) {
 #' glex_rpf <- glex(rp, mtcars[27:32, ])
 #' str(glex_rpf, list.len = 5)
 #' }
-glex.rpf <- function(object, x, max_interaction = NULL, ...) {
+glex.rpf <- function(object, x, max_interaction = NULL, features = NULL, ...) {
   if (!requireNamespace("randomPlantedForest", quietly = TRUE)) {
     stop(paste0("randomPlantedForest needs to be installed: ",
                 "remotes::install_github(\"PlantedML/randomPlantedForest\")"))
@@ -59,7 +60,7 @@ glex.rpf <- function(object, x, max_interaction = NULL, ...) {
 
   ret <- randomPlantedForest::predict_components(
     object = object, new_data = x, max_interaction = max_interaction,
-    predictors = NULL
+    predictors = features
   )
   # class(ret) <- c("glex", "rpf_components", class(ret))
   ret
@@ -91,7 +92,7 @@ glex.rpf <- function(object, x, max_interaction = NULL, ...) {
 #' glex(xg, x[27:32, ])
 #' }
 #' }
-glex.xgb.Booster <- function(object, x, max_interaction = NULL, ...) {
+glex.xgb.Booster <- function(object, x, max_interaction = NULL, features = NULL, ...) {
 
   if (!requireNamespace("xgboost", quietly = TRUE)) {
     stop("xgboost needs to be installed: install.packages(\"xgboost\")")
@@ -111,7 +112,7 @@ glex.xgb.Booster <- function(object, x, max_interaction = NULL, ...) {
   trees <- xgboost::xgb.model.dt.tree(model = object, use_int_id = TRUE)
 
   # Calculate components
-  res <- calc_components(trees, x, max_interaction)
+  res <- calc_components(trees, x, max_interaction, features)
   res$intercept <- res$intercept + 0.5
   
   # Return components
@@ -144,7 +145,7 @@ glex.xgb.Booster <- function(object, x, max_interaction = NULL, ...) {
 #' glex(rf, x[27:32, ])
 #' }
 #' }
-glex.ranger <- function(object, x, max_interaction = NULL, ...) {
+glex.ranger <- function(object, x, max_interaction = NULL, features = NULL, ...) {
   
   # To avoid data.table check issues
   terminal <- NULL
@@ -184,7 +185,7 @@ glex.ranger <- function(object, x, max_interaction = NULL, ...) {
   colnames(trees) <- c("Node", "Yes", "No", "Feature", "Split", "Cover", "Quality", "Tree")
     
   # Calculate components
-  res <- calc_components(trees, x, max_interaction)
+  res <- calc_components(trees, x, max_interaction, features)
   
   # Divide everything by the number of trees
   res$shap <- res$shap / object$num.trees
@@ -195,7 +196,7 @@ glex.ranger <- function(object, x, max_interaction = NULL, ...) {
   res
 } 
 
-calc_components <- function(trees, x, max_interaction) {
+calc_components <- function(trees, x, max_interaction, features) {
   # To avoid data.table check issues
   Tree <- NULL
   Feature <- NULL
@@ -211,12 +212,21 @@ calc_components <- function(trees, x, max_interaction) {
   }
 
   # Convert features to numerics (leaf = 0)
-  trees[, Feature_num := as.numeric(factor(Feature, levels = c("Leaf", colnames(x)))) - 1]
-
-  # All subsets S (that appear in any of the trees)
-  all_S <- unique(do.call(c,lapply(0:max(trees$Tree), function(tree) {
-    subsets(trees[Tree == tree & Feature_num > 0, sort(unique(as.integer(Feature_num)))])
-  })))
+  trees[, Feature_num := as.integer(factor(Feature, levels = c("Leaf", colnames(x)))) - 1L]
+  
+  if (is.null(features)) {
+    # All subsets S (that appear in any of the trees)
+    all_S <- unique(do.call(c,lapply(0:max(trees$Tree), function(tree) {
+      subsets(trees[Tree == tree & Feature_num > 0, sort(unique(Feature_num))])
+    })))
+  } else {
+    # All subsets with supplied features
+    if (!all(features %in% colnames(x))) {
+      stop("All selected features have to be column names of x.")
+    }
+    features_num <- as.integer(factor(features, levels = c("Leaf", colnames(x)))) - 1L
+    all_S <- subsets(sort(unique(features_num)))
+  }
 
   # Keep only those with not more than max_interaction involved features
   d <- lengths(all_S)
@@ -227,7 +237,7 @@ calc_components <- function(trees, x, max_interaction) {
     # Calculate matrix
     tree_info <- trees[Tree == tree, ]
 
-    T <- setdiff(tree_info[, sort(unique(Feature_num))], 0)
+    T <- setdiff(tree_info[, sort(unique(Feature_num))], 0L)
     U <- subsets(T)
     mat <- recurse(x, tree_info$Feature_num, tree_info$Split, tree_info$Yes, tree_info$No,
                    tree_info$Quality, tree_info$Cover, U, 0)
@@ -237,14 +247,12 @@ calc_components <- function(trees, x, max_interaction) {
 
     # Init m matrix
     m_all <- matrix(0, nrow = nrow(x), ncol = length(all_S))
-      #browser()
     colnames(m_all) <- vapply(all_S, function(s) {
       paste(sort(colnames(x)[s]), collapse = ":")
     }, FUN.VALUE = character(1))
 
-    # Calculate contribution, use only subsets with not more than max_interaction involved features
-    d <- lengths(U)
-    for (S in U[d <= max_interaction]) {
+    # Calculate contribution, use only selected features and subsets with not more than max_interaction involved features
+    for (S in intersect(U, all_S)) {
       colname <- paste(sort(colnames(x)[S]), collapse = ":")
       if (nchar(colname) == 0) {
         colnum <- 1

--- a/R/glex.R
+++ b/R/glex.R
@@ -164,13 +164,13 @@ glex.ranger <- function(object, x, max_interaction = NULL, ...) {
   
   # If max_interaction is not specified, we set it to the max.depth param of the ranger model.
   # If max.depth is not defined in ranger, we assume 6 as in xgboost.
-  rf_max_depth <- ifelse((is.null(object$max.depth) | object$max.depth == 0), 6L, object$max.depth)
+  rf_max_depth <- ifelse((is.null(object$max.depth) || object$max.depth == 0), 6L, object$max.depth)
   
   if (is.null(max_interaction)) {
     max_interaction <- rf_max_depth
   }
   
-  checkmate::assert_int(max_interaction, lower = 1, upper = rf_max_depth)
+  checkmate::assert_int(max_interaction, lower = 1, upper = Inf)
   
   # Convert model into xgboost format
   trees <- rbindlist(lapply(seq_len(object$num.trees), function(i) {

--- a/R/glex.R
+++ b/R/glex.R
@@ -129,7 +129,7 @@ glex.xgb.Booster <- function(object, x, max_interaction = NULL, ...) {
 #' library(ranger)
 #' x <- as.matrix(mtcars[, -1])
 #' y <- mtcars$mpg
-#' rf <- ranger(data = x[1:26, ], label = y[1:26],
+#' rf <- ranger(x = x[1:26, ], y = y[1:26],
 #'              num.trees = 5, max.depth = 3, 
 #'              node.stats = TRUE)
 #' glex(rf, x[27:32, ])

--- a/R/glex.R
+++ b/R/glex.R
@@ -142,6 +142,14 @@ glex.xgb.Booster <- function(object, x, max_interaction = NULL, ...) {
 #' }
 glex.ranger <- function(object, x, max_interaction = NULL, ...) {
   
+  # To avoid data.table check issues
+  terminal <- NULL
+  splitvarName <- NULL
+  splitStat <- NULL
+  prediction <- NULL
+  splitvarID <- NULL
+  tree <- NULL
+  
   if (!requireNamespace("ranger", quietly = TRUE)) {
     stop("ranger needs to be installed: install.packages(\"ranger\")")
   }

--- a/R/glex.R
+++ b/R/glex.R
@@ -111,7 +111,11 @@ glex.xgb.Booster <- function(object, x, max_interaction = NULL, ...) {
   trees <- xgboost::xgb.model.dt.tree(model = object, use_int_id = TRUE)
 
   # Calculate components
-  calc_components(trees, x, max_interaction)
+  res <- calc_components(trees, x, max_interaction)
+  res$intercept <- res$intercept + 0.5
+  
+  # Return components
+  res
 } 
 
 #' @rdname glex
@@ -283,7 +287,7 @@ calc_components <- function(trees, x, max_interaction) {
   ret <- list(
     shap = data.table::setDT(as.data.frame(shap)),
     m = data.table::setDT(as.data.frame(m_all[, -1])),
-    intercept = unique(m_all[, 1]) + 0.5,
+    intercept = unique(m_all[, 1]),
     x = data.table::setDT(as.data.frame(x))
   )
   class(ret) <- c("glex", "xgb_components", class(ret))

--- a/man/glex.Rd
+++ b/man/glex.Rd
@@ -82,7 +82,7 @@ if (requireNamespace("ranger", quietly = TRUE)) {
 library(ranger)
 x <- as.matrix(mtcars[, -1])
 y <- mtcars$mpg
-rf <- ranger(data = x[1:26, ], label = y[1:26],
+rf <- ranger(x = x[1:26, ], y = y[1:26],
              num.trees = 5, max.depth = 3, 
              node.stats = TRUE)
 glex(rf, x[27:32, ])

--- a/man/glex.Rd
+++ b/man/glex.Rd
@@ -11,9 +11,9 @@ glex(object, x, max_interaction = NULL, features = NULL, ...)
 
 \method{glex}{rpf}(object, x, max_interaction = NULL, features = NULL, ...)
 
-\method{glex}{xgb.Booster}(object, x, max_interaction = NULL, features = NULL, ...)
+\method{glex}{xgb.Booster}(object, x, max_interaction = NULL, features = NULL, cov_args = NULL, ...)
 
-\method{glex}{ranger}(object, x, max_interaction = NULL, features = NULL, ...)
+\method{glex}{ranger}(object, x, max_interaction = NULL, features = NULL, cov_args = NULL, ...)
 }
 \arguments{
 \item{object}{Model to be explained, either of class \code{xgb.Booster} or \code{rpf}.}

--- a/man/glex.Rd
+++ b/man/glex.Rd
@@ -4,6 +4,7 @@
 \alias{glex}
 \alias{glex.rpf}
 \alias{glex.xgb.Booster}
+\alias{glex.ranger}
 \title{Global explanations for tree-based models.}
 \usage{
 glex(object, x, max_interaction = NULL, ...)
@@ -11,6 +12,8 @@ glex(object, x, max_interaction = NULL, ...)
 \method{glex}{rpf}(object, x, max_interaction = NULL, ...)
 
 \method{glex}{xgb.Booster}(object, x, max_interaction = NULL, ...)
+
+\method{glex}{ranger}(object, x, max_interaction = NULL, ...)
 }
 \arguments{
 \item{object}{Model to be explained, either of class \code{xgb.Booster} or \code{rpf}.}
@@ -72,6 +75,22 @@ glex(xg, x[27:32, ])
 # Parallel execution
 doParallel::registerDoParallel()
 glex(xg, x[27:32, ])
+}
+}
+# ranger -----
+if (requireNamespace("ranger", quietly = TRUE)) {
+library(ranger)
+x <- as.matrix(mtcars[, -1])
+y <- mtcars$mpg
+rf <- ranger(data = x[1:26, ], label = y[1:26],
+             num.trees = 5, max.depth = 3, 
+             node.stats = TRUE)
+glex(rf, x[27:32, ])
+
+\dontrun{
+# Parallel execution
+doParallel::registerDoParallel()
+glex(rf, x[27:32, ])
 }
 }
 }

--- a/man/glex.Rd
+++ b/man/glex.Rd
@@ -7,13 +7,13 @@
 \alias{glex.ranger}
 \title{Global explanations for tree-based models.}
 \usage{
-glex(object, x, max_interaction = NULL, ...)
+glex(object, x, max_interaction = NULL, features = NULL, ...)
 
-\method{glex}{rpf}(object, x, max_interaction = NULL, ...)
+\method{glex}{rpf}(object, x, max_interaction = NULL, features = NULL, ...)
 
-\method{glex}{xgb.Booster}(object, x, max_interaction = NULL, ...)
+\method{glex}{xgb.Booster}(object, x, max_interaction = NULL, features = NULL, ...)
 
-\method{glex}{ranger}(object, x, max_interaction = NULL, ...)
+\method{glex}{ranger}(object, x, max_interaction = NULL, features = NULL, ...)
 }
 \arguments{
 \item{object}{Model to be explained, either of class \code{xgb.Booster} or \code{rpf}.}
@@ -25,6 +25,8 @@ Maximum interaction size to consider.
 Defaults to using all possible interactions available in the model.\cr
 For \code{\link[xgboost:xgb.train]{xgboost}}, this defaults to the \code{max_depth} parameter of the model fit.\cr
 If not set in \code{xgboost}, the default value of \code{6} is assumed.}
+
+\item{features}{Vector of column names in x to calculate components for. If \code{NULL}, all features are used.}
 
 \item{...}{Further arguments passed to methods.}
 }

--- a/tests/testthat/test-glex-xgboost.R
+++ b/tests/testthat/test-glex-xgboost.R
@@ -30,3 +30,27 @@ test_that("max_interaction respects xgb's max_depth", {
   expect_equal(max_degree, 7)
   expect_error(glex(xg, x, max_interaction = 8))
 })
+
+test_that("features argument only calculates for given feautures", {
+  x <- as.matrix(mtcars[, -1])
+  xg <- xgboost(x, mtcars$mpg, nrounds = 10, verbose = 0)
+  glexb <- glex(xg, x, features = c("cyl", "disp"))
+  expect_equal(colnames(glexb$m), c("cyl", "disp", "cyl:disp"))
+})
+
+test_that("features argument results in same values as without", {
+  x <- as.matrix(mtcars[, -1])
+  xg <- xgboost(x, mtcars$mpg, nrounds = 10, verbose = 0)
+  glexb1 <- glex(xg, x, features = c("cyl", "disp"))
+  glexb2 <- glex(xg, x)
+  cols <- c("cyl", "disp", "cyl:disp")
+  expect_equal(glexb1$m[, ..cols], glexb2$m[, ..cols])
+})
+
+test_that("features argument works together with max_interaction", {
+  x <- as.matrix(mtcars[, -1])
+  xg <- xgboost(x, mtcars$mpg, nrounds = 10, verbose = 0)
+  glexb <- glex(xg, x, features = c("cyl", "disp"), max_interaction = 1)
+  expect_equal(colnames(glexb$m), c("cyl", "disp"))
+})
+

--- a/tests/testthat/test-mtcars-ranger.R
+++ b/tests/testthat/test-mtcars-ranger.R
@@ -1,0 +1,38 @@
+x_train <- as.matrix(mtcars[1:26, -1])
+x_test <- as.matrix(mtcars[27:32, -1])
+y_train <- mtcars$mpg[1:26]
+y_test <- mtcars$mpg[27:32]
+
+# xgboost
+rf <- ranger(x = x_train, y = y_train, node.stats = TRUE, 
+             num.trees = 5, max.depth = 4)
+pred_train <- predict(rf, x_train)$predictions
+pred_test <- predict(rf, x_test)$predictions
+
+# Decompositions
+res_train <- glex(rf, x_train, max_interaction = 4)
+res_test <- glex(rf, x_test, max_interaction = 4)
+
+test_that("Prediction is approx. same as sum of shap + intercept, training data", {
+  expect_equal(res_train$intercept + rowSums(res_train$shap),
+               pred_train,
+               tolerance = 1e-5)
+})
+
+test_that("Prediction is approx. same as sum of shap + intercept, test data", {
+  expect_equal(res_test$intercept + rowSums(res_test$shap),
+               pred_test,
+               tolerance = 1e-5)
+})
+
+test_that("Prediction is approx. same as sum of decomposition + intercept, training data", {
+  expect_equal(res_train$intercept + rowSums(res_train$m),
+               pred_train,
+               tolerance = 1e-5)
+})
+
+test_that("Prediction is approx. same as sum of decomposition + intercept, test data", {
+  expect_equal(res_test$intercept + rowSums(res_test$m),
+               pred_test,
+               tolerance = 1e-5)
+})

--- a/tests/testthat/test-mtcars-ranger.R
+++ b/tests/testthat/test-mtcars-ranger.R
@@ -1,3 +1,5 @@
+library(ranger)
+
 x_train <- as.matrix(mtcars[1:26, -1])
 x_test <- as.matrix(mtcars[27:32, -1])
 y_train <- mtcars$mpg[1:26]


### PR DESCRIPTION
If we know the distribution of x, we can calculate the true coverage of the nodes with `pmvnorm` and the node boundaries based on the splits. 

**Not to be merged into main for now!** 

Example: 

````R
library(mvtnorm)
library(xgboost)
library(glex)

# Simulate from multivariate normal
n <- 1000
p <- 2
beta <- c(1, 1)
beta0 <- 0
cov_base <- 0.3
mu <- c(0, 0)
sigma <- toeplitz(cov_base^(0:(p-1)))
x <- matrix(rmvnorm(n = n, sigma = sigma), ncol = p,
            dimnames = list(NULL, paste0('x', seq_len(p))))
lp <- x %*% beta + beta0 + 2*x[, 1] * x[, 2]
y <- lp + rnorm(n)

# xgboost
xg <- xgboost(data = x, label = y, params = list(max_depth = 4, eta = .1), nrounds = 10, verbose = 0)

# SHAP decomposition
glex(xg, x, cov_args = list(mu, sigma))
````