### PR TITLE
Calculate shap values only for the selected features

### DIFF
--- a/R/glex.R
+++ b/R/glex.R
@@ -380,7 +380,10 @@ calc_components <- function(trees, x, max_interaction, features, probFunction = 
   interactions <- sweep(m_all[, -1, drop = FALSE], MARGIN = 2, d[-1], "/")
 
   # SHAP values are the sum of the m's * 1/d
-  shap <- vapply(colnames(x), function(col) {
+  if (is.null(features)) {
+    features <- colnames(x)
+  }
+  shap <- vapply(features, function(col) {
     idx <- find_term_matches(col, colnames(interactions))
 
     if (length(idx) == 0) {


### PR DESCRIPTION
While the components were correct, the SHAP values were all 0 for the non-selected features, as in this example from #13: 

```R
library(glex)
library(xgboost)

x <- as.matrix(mtcars[, -1])
y <- mtcars$mpg

xg <- xgboost(data = x, label = y, params = list(max_depth = 4, eta = .1), nrounds = 100, verbose = 0)

glex(xg, x, features = c("cyl", "disp"))
````

But I wonder, should we even calculate the SHAP values? They are not correct SHAP values anyway because we just ignored some of the features. That means, in the above example and 

````R
res1 <- glex(xg, x, features = c("cyl", "disp"))
res2 <- glex(xg, x)
````

the components `res1$m` and `res2$m` are the same, but the SHAP values `res1$shap` and `res2$shap` not.
