### PR TITLE
Make glex work with new xgboost version

### DIFF
--- a/R/glex.R
+++ b/R/glex.R
@@ -119,6 +119,9 @@ glex.xgb.Booster <- function(object, x, max_interaction = NULL, features = NULL,
   # Convert model
   trees <- xgboost::xgb.model.dt.tree(model = object, use_int_id = TRUE)
   trees$Type <- "<"
+  if ("Gain" %in% colnames(trees)) {
+    data.table::setnames(trees, "Gain", "Quality")
+  }
 
   # Calculate components
   res <- calc_components(trees, x, max_interaction, features, weighting_method, max_background_sample_size)


### PR DESCRIPTION
In the new xgboost release, the "Quality" column in the output of `xgboost::xgb.model.dt.tree()` was renamed to "Gain. 