### PR TITLE
Update XGBoost adapter to work with new columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: glex
 Title: Global Explanations for Tree-Based Models
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person(c("Marvin", "N."), "Wright", , "cran@wrig.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8542-6291")),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(autoplot,glex)
 S3method(autoplot,glex_vi)
+S3method(glex,default)
 S3method(glex,ranger)
 S3method(glex,rpf)
 S3method(glex,xgb.Booster)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# glex 0.5.2
+
+* **Fix newer xgboost R package compatibility**:
+  - Updated tree schema column name from `Quality` to `Gain`, matching xgboost commit 73713de (`[R] rename Quality -> Gain (#9938)`, in upstream v2.1.0)
+  - Implemented dynamic `base_score` extraction to replace hardcoded 0.5 intercept (modern xgboost auto-estimates `base_score`)
+  - Fixed floating-point precision mismatch in C++ split comparators by casting to float, matching xgboost predictor behavior
+  - Added node reindexing to ensure contiguous row ordering in tree matrices
+  - For CRAN users, this schema change is observed in the later 3.x package line (for example 3.1.2.1+), which requires R >= 4.3.0
+  - These changes ensure accurate model explanations for current CRAN xgboost releases
+
+
 # glex 0.5.1
 
 * Fix path-dependent algorithm by computing the proper covers manually

--- a/R/data_bike.R
+++ b/R/data_bike.R
@@ -1,7 +1,7 @@
 #' Bikesharing data
 #'
 #' A reduced version of the `Bikeshare` data as included with `ISLR2`.
-#' The dataset has been converted to a [`data.table`], with the following changes:
+#' The dataset has been converted to a [data.table::data.table()], with the following changes:
 #'
 #' - `hr` has been copnverted to a numeric
 #' - `workingday` was recoded to a binary `factor` with labels `c("No Workingday", "Workingday")`

--- a/R/glex.R
+++ b/R/glex.R
@@ -31,7 +31,8 @@ glex <- function(object, x, max_interaction = NULL, features = NULL, ...) {
   UseMethod("glex")
 }
 
-#' @noRd
+#' @rdname glex
+#' @export
 glex.default <- function(object, ...) {
   stop(
     "`glex()` is not defined for a '", class(object)[1], "'.",

--- a/R/glex.R
+++ b/R/glex.R
@@ -122,10 +122,66 @@ glex.xgb.Booster <- function(object, x, max_interaction = NULL, features = NULL,
 
   # Calculate components
   res <- calc_components(trees, x, max_interaction, features, weighting_method, max_background_sample_size)
-  res$intercept <- res$intercept + 0.5
+  res$intercept <- res$intercept + get_xgb_base_score(object)
 
   # Return components
   res
+}
+
+
+#' @keywords internal
+#' @noRd
+get_xgb_base_score <- function(object) {
+  parse_base_score <- function(x) {
+    if (is.null(x) || length(x) == 0) {
+      return(NA_real_)
+    }
+
+    x <- as.character(x[[1]])
+    # Newer xgboost may serialize as "[2.0090626E1]".
+    x <- gsub("^\\[|\\]$", "", x)
+    x <- trimws(x)
+
+    # Handle potential vector-like encodings by taking the first element.
+    x <- strsplit(x, ",", fixed = TRUE)[[1]][1]
+    x <- trimws(x)
+
+    suppressWarnings(as.numeric(x))
+  }
+
+  # Newer xgboost versions store base_score in config; older versions may expose xgb.attr().
+  config <- tryCatch(xgboost::xgb.config(object), error = function(e) NULL)
+
+  if (is.list(config)) {
+    base_score <- tryCatch(config$learner$learner_model_param$base_score, error = function(e) NULL)
+    if (!is.null(base_score)) {
+      base_score_num <- parse_base_score(base_score)
+      if (!is.na(base_score_num)) {
+        return(base_score_num)
+      }
+    }
+  }
+
+  if (is.character(config) && length(config) == 1) {
+    # Fallback parser for JSON-string configs to avoid introducing a jsonlite dependency.
+    m <- regexpr('"base_score"\\s*:\\s*"?([^",}]+)"?', config, perl = TRUE)
+    if (m != -1) {
+      match_str <- regmatches(config, m)
+      base_score <- sub('.*"base_score"\\s*:\\s*"?([^",}]+)"?.*', '\\1', match_str, perl = TRUE)
+      base_score_num <- parse_base_score(base_score)
+      if (!is.na(base_score_num)) {
+        return(base_score_num)
+      }
+    }
+  }
+
+  base_score_attr <- parse_base_score(xgboost::xgb.attr(object, "base_score"))
+  if (length(base_score_attr) == 1 && !is.na(base_score_attr)) {
+    return(base_score_attr)
+  }
+
+  warning("Could not determine xgboost base_score. Falling back to legacy default 0.5.")
+  0.5
 }
 
 #' @rdname glex
@@ -202,7 +258,7 @@ glex.ranger <- function(object, x, max_interaction = NULL, features = NULL, max_
   trees[, splitvarID := NULL]
   trees[, terminal := NULL]
   trees[, prediction := NULL]
-  colnames(trees) <- c("Node", "Yes", "No", "Feature", "Split", "Cover", "Quality", "Tree")
+  colnames(trees) <- c("Node", "Yes", "No", "Feature", "Split", "Cover", "Gain", "Tree")
   trees$Type <- "<="
 
   # Calculate components
@@ -221,8 +277,10 @@ glex.ranger <- function(object, x, max_interaction = NULL, features = NULL, max_
 tree_fun_path_dependent <- function(tree, trees, x, all_S, max_interaction) {
   # Prepare tree_info for C++ function
   tree_info <- trees[get("Tree") == tree, ]
+  max_node <- max(tree_info$Node)
+  tree_info <- tree_info[data.table::data.table(Node = 0:max_node), on = "Node"]
   tree_info[, "Feature" := get("Feature_num") - 1L] # Adjust to 0-based for C++ bitmasks
-  to_select <- c("Feature", "Split", "Yes", "No", "Quality")
+  to_select <- c("Feature", "Split", "Yes", "No", "Gain")
   tree_mat <- tree_info[, to_select, with = FALSE] # Use with=FALSE to avoid data.table check issues
   tree_mat[is.na(tree_mat)] <- -1L # Use -1 for leaf nodes
   tree_mat <- as.matrix(tree_mat)
@@ -248,8 +306,9 @@ tree_fun_emp <- function(tree, trees, x, all_S, max_interaction) {
 
   # Calculate matrix
   tree_info <- trees[Tree == tree, ]
-
   max_node <- trees[Tree == tree, max(Node)]
+  tree_info <- tree_info[data.table::data.table(Node = 0:max_node), on = "Node"]
+
   num_nodes <- max_node + 1
   lb <- matrix(-Inf, nrow = num_nodes, ncol = ncol(x))
   ub <- matrix(Inf, nrow = num_nodes, ncol = ncol(x))
@@ -276,7 +335,7 @@ tree_fun_emp <- function(tree, trees, x, all_S, max_interaction) {
   mat <- recurseRcppEmpProbfunction(x,
     tree_info$Feature_num, tree_info$Split,
     tree_info$Yes, tree_info$No,
-    tree_info$Quality, lb, ub, integer(0), U, 0)
+    tree_info$Gain, lb, ub, integer(0), U, 0)
 
   colnames(mat) <- vapply(U, function(u) {
     paste(sort(colnames(x)[u]), collapse = ":")
@@ -305,8 +364,10 @@ tree_fun_emp <- function(tree, trees, x, all_S, max_interaction) {
 tree_fun_emp_fastPD <- function(tree, trees, x, background_sample, all_S, max_interaction) {
   # Calculate matrix
   tree_info <- trees[get("Tree") == tree, ]
+  max_node <- max(tree_info$Node)
+  tree_info <- tree_info[data.table::data.table(Node = 0:max_node), on = "Node"]
   tree_info[, "Feature" := get("Feature_num") - 1L]
-  to_select <- c("Feature", "Split", "Yes", "No", "Quality")
+  to_select <- c("Feature", "Split", "Yes", "No", "Gain")
   tree_mat <- tree_info[, to_select, with = FALSE]
   tree_mat[is.na(tree_mat)] <- -1L
   tree_mat <- as.matrix(tree_mat)

--- a/R/glex_vi.R
+++ b/R/glex_vi.R
@@ -3,7 +3,7 @@
 #' @param object Object of class `glex`.
 #' @param ... (Unused)
 #'
-#' @return A [`data.table`] with columns:
+#' @return A [data.table::data.table()] with columns:
 #' * `degree` (`integer`): Degree of interaction of the `term`, with `1` being main effects,
 #'    `2` being 2-degree interactions etc.
 #' * `term` (`character`): Model term, e.g. main effect `x1` or interaction term `x1:x2`, `x1:x3:x5` etc.

--- a/man/bike.Rd
+++ b/man/bike.Rd
@@ -15,7 +15,7 @@ bike
 }
 \description{
 A reduced version of the \code{Bikeshare} data as included with \code{ISLR2}.
-The dataset has been converted to a \code{\link{data.table}}, with the following changes:
+The dataset has been converted to a \code{\link[data.table:data.table]{data.table::data.table()}}, with the following changes:
 }
 \details{
 \itemize{

--- a/man/glex.Rd
+++ b/man/glex.Rd
@@ -2,12 +2,15 @@
 % Please edit documentation in R/glex.R
 \name{glex}
 \alias{glex}
+\alias{glex.default}
 \alias{glex.rpf}
 \alias{glex.xgb.Booster}
 \alias{glex.ranger}
 \title{Global explanations for tree-based models.}
 \usage{
 glex(object, x, max_interaction = NULL, features = NULL, ...)
+
+\method{glex}{default}(object, ...)
 
 \method{glex}{rpf}(object, x, max_interaction = NULL, features = NULL, ...)
 
@@ -94,6 +97,7 @@ xg <- xgboost(data = x[1:26, ], label = y[1:26],
               params = list(max_depth = 4, eta = .1),
               nrounds = 10, verbose = 0)
 glex(xg, x[27:32, ])
+glex(xg, mtcars[27:32, ])
 
 \dontrun{
 # Parallel execution
@@ -110,6 +114,7 @@ rf <- ranger(x = x[1:26, ], y = y[1:26],
              num.trees = 5, max.depth = 3,
              node.stats = TRUE)
 glex(rf, x[27:32, ])
+glex(rf, mtcars[27:32, ])
 
 \dontrun{
 # Parallel execution

--- a/man/glex_vi.Rd
+++ b/man/glex_vi.Rd
@@ -12,7 +12,7 @@ glex_vi(object, ...)
 \item{...}{(Unused)}
 }
 \value{
-A \code{\link{data.table}} with columns:
+A \code{\link[data.table:data.table]{data.table::data.table()}} with columns:
 \itemize{
 \item \code{degree} (\code{integer}): Degree of interaction of the \code{term}, with \code{1} being main effects,
 \code{2} being 2-degree interactions etc.

--- a/src/comparison_policies.h
+++ b/src/comparison_policies.h
@@ -3,13 +3,19 @@
 namespace glex
 {
 
+  inline float as_float(double x)
+  {
+    return static_cast<float>(x);
+  }
+
   // Comparison policy classes
   struct StrictComparison
   {
     template <typename T>
     static bool compare(const T &a, const T &b)
     {
-      return a < b;
+      // xgboost prediction uses float split comparisons, so mirror that precision.
+      return as_float(static_cast<double>(a)) < as_float(static_cast<double>(b));
     }
   };
 
@@ -18,7 +24,8 @@ namespace glex
     template <typename T>
     static bool compare(const T &a, const T &b)
     {
-      return a <= b;
+      // Keep weak comparator in the same numeric precision for consistency.
+      return as_float(static_cast<double>(a)) <= as_float(static_cast<double>(b));
     }
   };
 

--- a/src/fastpd_explain_tree_bitmask.cpp
+++ b/src/fastpd_explain_tree_bitmask.cpp
@@ -196,9 +196,9 @@ Rcpp::NumericMatrix recurseMarginalizeSBitmask(
   // If leaf node
   if (current_feature == -1)
   {
-    // We'll fill each column with (quality * p) for all rows,
+    // We'll fill each column with (gain * p) for all rows,
     // where p = leafProbs[node][(encounteredMask[node] \ U[j])]
-    const double quality = current_node[Index::QUALITY];
+    const double gain = current_node[Index::GAIN];
 
     for (unsigned int j = 0; j < n_subsets; ++j)
     {
@@ -211,7 +211,7 @@ Rcpp::NumericMatrix recurseMarginalizeSBitmask(
       {
         p = it->second;
       }
-      double val = quality * p;
+      double val = gain * p;
 
       // Fill column j with val
       double *col_out = &mat(0, j);

--- a/src/glex.h
+++ b/src/glex.h
@@ -27,7 +27,7 @@ enum Index
   SPLIT = 1,
   YES = 2,
   NO = 3,
-  QUALITY = 4,
+  GAIN = 4,
   COVER = 5
 };
 

--- a/src/path_dependent_explain_tree.cpp
+++ b/src/path_dependent_explain_tree.cpp
@@ -109,7 +109,7 @@ NumericMatrix recursePathDependent(
 
   if (current_feature == -1)
   {
-    double pred = current_node[Index::QUALITY];
+    double pred = current_node[Index::GAIN];
     std::fill(mat.begin(), mat.end(), pred);
   }
   else

--- a/tests/testthat/test-glex-xgboost.R
+++ b/tests/testthat/test-glex-xgboost.R
@@ -51,58 +51,58 @@ res_test_path <- glex(xg, x_test, max_interaction = 4, weighting_method = "path-
 
 
 test_that("FastPD xgboost prediction is approx. same as sum of shap + intercept, training data", {
-  expect_equal(res_train$intercept + rowSums(res_train$shap),
-    pred_train,
+  expect_equal(unname(res_train$intercept + rowSums(res_train$shap)),
+    unname(pred_train),
     tolerance = 1e-5
   )
 })
 
 test_that("FastPD xgboost prediction is approx. same as sum of shap + intercept, test data", {
-  expect_equal(res_test$intercept + rowSums(res_test$shap),
-    pred_test,
+  expect_equal(unname(res_test$intercept + rowSums(res_test$shap)),
+    unname(pred_test),
     tolerance = 1e-5
   )
 })
 
 test_that("FastPD xgboost prediction is approx. same as sum of decomposition + intercept, training data", {
-  expect_equal(res_train$intercept + rowSums(res_train$m),
-    pred_train,
+  expect_equal(unname(res_train$intercept + rowSums(res_train$m)),
+    unname(pred_train),
     tolerance = 1e-5
   )
 })
 
 test_that("FastPD xgboost prediction is approx. same as sum of decomposition + intercept, test data", {
-  expect_equal(res_test$intercept + rowSums(res_test$m),
-    pred_test,
+  expect_equal(unname(res_test$intercept + rowSums(res_test$m)),
+    unname(pred_test),
     tolerance = 1e-5
   )
 })
 
 
 test_that("Path-dependent xgboost prediction is approx. same as sum of shap + intercept, training data", {
-  expect_equal(res_train_path$intercept + rowSums(res_train_path$shap),
-    pred_train,
+  expect_equal(unname(res_train_path$intercept + rowSums(res_train_path$shap)),
+    unname(pred_train),
     tolerance = 1e-5
   )
 })
 
 test_that("Path-dependent xgboost prediction is approx. same as sum of shap + intercept, test data", {
-  expect_equal(res_test_path$intercept + rowSums(res_test_path$shap),
-    pred_test,
+  expect_equal(unname(res_test_path$intercept + rowSums(res_test_path$shap)),
+    unname(pred_test),
     tolerance = 1e-5
   )
 })
 
 test_that("Path-dependent xgboost prediction is approx. same as sum of decomposition + intercept, training data", {
-  expect_equal(res_train_path$intercept + rowSums(res_train_path$m),
-    pred_train,
+  expect_equal(unname(res_train_path$intercept + rowSums(res_train_path$m)),
+    unname(pred_train),
     tolerance = 1e-5
   )
 })
 
 test_that("Path-dependent xgboost prediction is approx. same as sum of decomposition + intercept, test data", {
-  expect_equal(res_test_path$intercept + rowSums(res_test_path$m),
-    pred_test,
+  expect_equal(unname(res_test_path$intercept + rowSums(res_test_path$m)),
+    unname(pred_test),
     tolerance = 1e-5
   )
 })

--- a/tests/testthat/test-glex-xgboost.R
+++ b/tests/testthat/test-glex-xgboost.R
@@ -106,3 +106,43 @@ test_that("Path-dependent xgboost prediction is approx. same as sum of decomposi
     tolerance = 1e-5
   )
 })
+
+test_that("xgboost models with different base_score values are reconstructed correctly", {
+  x_train <- as.matrix(mtcars[1:26, -1])
+  x_test <- as.matrix(mtcars[27:32, -1])
+  y_train <- mtcars$mpg[1:26]
+
+  base_scores <- c(0.5, 5, 20)
+  dtrain <- xgboost::xgb.DMatrix(data = x_train, label = y_train)
+
+  for (bs in base_scores) {
+    xg_bs <- xgboost::xgb.train(
+      params = list(
+        objective = "reg:squarederror",
+        max_depth = 4,
+        eta = 0.1,
+        base_score = bs
+      ),
+      data = dtrain,
+      nrounds = 10,
+      verbose = 0
+    )
+
+    pred_bs <- predict(xg_bs, x_test)
+    res_bs <- glex(xg_bs, x_test, max_interaction = 4, weighting_method = "fastpd")
+
+    expect_equal(
+      get_xgb_base_score(xg_bs),
+      bs,
+      tolerance = 1e-10,
+      info = paste0("base_score extraction failed for base_score=", bs)
+    )
+
+    expect_equal(
+      unname(res_bs$intercept + rowSums(res_bs$shap)),
+      unname(pred_bs),
+      tolerance = 1e-5,
+      info = paste0("reconstruction failed for base_score=", bs)
+    )
+  }
+})

--- a/tests/testthat/test-mtcars.R
+++ b/tests/testthat/test-mtcars.R
@@ -13,25 +13,25 @@ res_train <- glex(xg, x_train)
 res_test <- glex(xg, x_test)
 
 test_that("Prediction is approx. same as sum of shap + intercept, training data", {
-  expect_equal(res_train$intercept + rowSums(res_train$shap),
-               pred_train,
+  expect_equal(unname(res_train$intercept + rowSums(res_train$shap)),
+               unname(pred_train),
                tolerance = 1e-5)
 })
 
 test_that("Prediction is approx. same as sum of shap + intercept, test data", {
-  expect_equal(res_test$intercept + rowSums(res_test$shap),
-               pred_test,
+  expect_equal(unname(res_test$intercept + rowSums(res_test$shap)),
+               unname(pred_test),
                tolerance = 1e-5)
 })
 
 test_that("Prediction is approx. same as sum of decomposition + intercept, training data", {
-  expect_equal(res_train$intercept + rowSums(res_train$m),
-               pred_train,
+  expect_equal(unname(res_train$intercept + rowSums(res_train$m)),
+               unname(pred_train),
                tolerance = 1e-5)
 })
 
 test_that("Prediction is approx. same as sum of decomposition + intercept, test data", {
-  expect_equal(res_test$intercept + rowSums(res_test$m),
-               pred_test,
+  expect_equal(unname(res_test$intercept + rowSums(res_test$m)),
+               unname(pred_test),
                tolerance = 1e-5)
 })

--- a/tests/testthat/test-sim.R
+++ b/tests/testthat/test-sim.R
@@ -36,50 +36,50 @@ resbin_train <- glex(xgbin, x_train)
 resbin_test <- glex(xgbin, x_test)
 
 test_that("regr: Prediction is approx. same as sum of shap + intercept, training data", {
-  expect_equal(res_train$intercept + rowSums(res_train$shap),
-               pred_train,
+  expect_equal(unname(res_train$intercept + rowSums(res_train$shap)),
+               unname(pred_train),
                tolerance = 1e-5)
 })
 
 test_that("binary: Prediction is approx. same as sum of shap + intercept, training data", {
-  expect_equal(resbin_train$intercept + rowSums(resbin_train$shap),
-               predbin_train,
+  expect_equal(unname(resbin_train$intercept + rowSums(resbin_train$shap)),
+               unname(predbin_train),
                tolerance = 1e-5)
 })
 
 test_that("regr: Prediction is approx. same as sum of shap + intercept, test data", {
-  expect_equal(res_test$intercept + rowSums(res_test$shap),
-               pred_test,
+  expect_equal(unname(res_test$intercept + rowSums(res_test$shap)),
+               unname(pred_test),
                tolerance = 1e-5)
 })
 
 test_that("binary: Prediction is approx. same as sum of shap + intercept, test data", {
-  expect_equal(resbin_test$intercept + rowSums(resbin_test$shap),
-               predbin_test,
+  expect_equal(unname(resbin_test$intercept + rowSums(resbin_test$shap)),
+               unname(predbin_test),
                tolerance = 1e-5)
 })
 
 test_that("regr: Prediction is approx. same as sum of decomposition + intercept, training data", {
-  expect_equal(res_train$intercept + rowSums(res_train$m),
-               pred_train,
+  expect_equal(unname(res_train$intercept + rowSums(res_train$m)),
+               unname(pred_train),
                tolerance = 1e-5)
 })
 
 test_that("classif: Prediction is approx. same as sum of decomposition + intercept, training data", {
-  expect_equal(resbin_train$intercept + rowSums(resbin_train$m),
-               predbin_train,
+  expect_equal(unname(resbin_train$intercept + rowSums(resbin_train$m)),
+               unname(predbin_train),
                tolerance = 1e-5)
 })
 
 test_that("regr: Prediction is approx. same as sum of decomposition + intercept, test data", {
-  expect_equal(res_test$intercept + rowSums(res_test$m),
-               pred_test,
+  expect_equal(unname(res_test$intercept + rowSums(res_test$m)),
+               unname(pred_test),
                tolerance = 1e-5)
 })
 
 test_that("binary: Prediction is approx. same as sum of decomposition + intercept, test data", {
-  expect_equal(resbin_test$intercept + rowSums(resbin_test$m),
-               predbin_test,
+  expect_equal(unname(resbin_test$intercept + rowSums(resbin_test$m)),
+               unname(predbin_test),
                tolerance = 1e-5)
 })
 


### PR DESCRIPTION
This pull request updates the `glex` package to improve compatibility with recent versions of the xgboost R package, particularly addressing changes in the tree schema and model serialization. The update ensures robust extraction of the `base_score` parameter, corrects floating-point precision issues in split comparisons, and adapts to the renaming of the `Quality` column to `Gain`. Several test and code adjustments are included to ensure correctness and future-proofing.

**xgboost compatibility and schema updates:**

* Updated all code and C++ interfaces to use the `Gain` column instead of `Quality` in tree matrices, following upstream xgboost changes. This affects both R and C++ code and ensures compatibility with xgboost v2.1.0+ and CRAN 3.x releases. [[1]](diffhunk://#diff-636b6d85262c576f84d49d49e062066f7b17db9306a053872f5749cc4808e355L205-R261) [[2]](diffhunk://#diff-636b6d85262c576f84d49d49e062066f7b17db9306a053872f5749cc4808e355R280-R283) [[3]](diffhunk://#diff-636b6d85262c576f84d49d49e062066f7b17db9306a053872f5749cc4808e355L279-R338) [[4]](diffhunk://#diff-636b6d85262c576f84d49d49e062066f7b17db9306a053872f5749cc4808e355R367-R370) [[5]](diffhunk://#diff-5480e2e5c7bfc79060d7306937915a7e59b5e2de588a97dc088c5e4faca87e46L30-R30) [[6]](diffhunk://#diff-866607bb02304c583682105d6832a1ba12802c66942d2db50b2f8cb34ca70bccL199-R201) [[7]](diffhunk://#diff-866607bb02304c583682105d6832a1ba12802c66942d2db50b2f8cb34ca70bccL214-R214) [[8]](diffhunk://#diff-66fdae2575d39a00ab75b52cfe2adaab2cc21bb6fc9e30ff1047414b51da85e3L112-R112)

* Implemented dynamic extraction of the `base_score` parameter from xgboost models, replacing the previously hardcoded intercept of 0.5. The new helper function `get_xgb_base_score` parses the value from various possible model storage formats.

**Numerical precision and correctness:**

* Adjusted C++ split comparators to cast values to `float` before comparison, matching xgboost predictor logic and avoiding floating-point precision mismatches. [[1]](diffhunk://#diff-f028f12b75f533f0fcb34e02da3f9669efb1cacfdec478e217e95d0173ecf534R6-R18) [[2]](diffhunk://#diff-f028f12b75f533f0fcb34e02da3f9669efb1cacfdec478e217e95d0173ecf534L21-R28)

* Added node reindexing to ensure contiguous row ordering in tree matrices, preventing errors when tree nodes are not sequentially numbered. [[1]](diffhunk://#diff-636b6d85262c576f84d49d49e062066f7b17db9306a053872f5749cc4808e355R280-R283) [[2]](diffhunk://#diff-636b6d85262c576f84d49d49e062066f7b17db9306a053872f5749cc4808e355L251-R311) [[3]](diffhunk://#diff-636b6d85262c576f84d49d49e062066f7b17db9306a053872f5749cc4808e355R367-R370)

**Testing and validation:**

* Expanded and updated tests to verify correct extraction and use of `base_score`, and to ensure predictions are reconstructed accurately for different `base_score` values. Also standardized test comparisons to use `unname()` for robust vector equality. [[1]](diffhunk://#diff-ed49e7c6bf34a597378cef984e71104ac98194231d24453052f29c3cb21408e2L54-R148) [[2]](diffhunk://#diff-ba2928b6f95a9d40393130201a7eefc7071a0ef33f18971c6a2b90547df6bcb3L16-R35) [[3]](diffhunk://#diff-9d6789671b64798e59f5d2224e95841dda7878d7d32d5af885674dc78d69eaf5L39-R82)

**Documentation and versioning:**

* Updated `NEWS.md` to document the compatibility fixes and rationale for CRAN users.
* Bumped the package version to 0.5.2 in the `DESCRIPTION` file.