### PR TITLE
Warn on missing values passed to `glex()` in `x` 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # glex 0.6.0.9000 (development version)
 
+* `glex()` now warns when `x` contains missing values (#41): splits are evaluated
+  without the model's learned missing-value direction, so the decomposition of rows
+  with `NA`s is unreliable and does not sum to the model prediction. Proper missing
+  value support needs more investigation; previously such input passed silently.
+
 * `glex()` on `xgboost` models fit with early stopping now decomposes only the trees
   up to `best_iteration`, matching what `predict()` evaluates by default. Previously
   all fitted trees were decomposed, so the components did not sum to the prediction.

--- a/R/glex.R
+++ b/R/glex.R
@@ -921,6 +921,17 @@ calc_components <- function(
   Feature_num <- NULL
   Tree <- NULL
 
+  # Splits are evaluated as plain comparisons, which route an NA to the "No"
+  # branch regardless of the missing-value direction the model learned, and NA
+  # rows distort the background sample used for marginalization (#41).
+  if (anyNA(x)) {
+    warning(
+      "`x` contains missing values. glex routes them through splits without ",
+      "the model's learned missing-value direction, so the decomposition is ",
+      "unreliable and will not sum to the model prediction."
+    )
+  }
+
   # Convert features to numerics (leaf = 0)
   unique_features_in_tree <- unique(trees$Feature)
   unique_features_in_tree <- unique_features_in_tree[

--- a/tests/testthat/test-glex-xgboost.R
+++ b/tests/testthat/test-glex-xgboost.R
@@ -368,3 +368,15 @@ test_that("early-stopped models are decomposed up to best_iteration, like predic
     tolerance = 1e-5
   )
 })
+
+test_that("missing values in x trigger a warning", {
+  set.seed(1)
+  x <- as.matrix(mtcars[, -1])
+  xg <- xgboost(x, mtcars$mpg, nrounds = 5, max_depth = 2, verbosity = 0)
+
+  x_na <- x
+  x_na[1, "cyl"] <- NA
+  expect_warning(glex(xg, x_na), "missing values")
+
+  expect_no_warning(glex(xg, x))
+})


### PR DESCRIPTION
A "proper" solution would require a much closer look I guess.

See #41